### PR TITLE
Cookie Nickname bug fix

### DIFF
--- a/client/Messaging.js
+++ b/client/Messaging.js
@@ -257,7 +257,10 @@ function initApp() {
         Utils.setCookie('nickname', name, 14);
 
         // update the app state
-        App.state.name = name;
+		App.state.name = name;
+
+		// update the chat title
+		App.dom.updateName();
 
         // destroy the editor
         App.dom.destoryEditor();


### PR DESCRIPTION
I found a bug where when I entered in my nickname, I would have to refresh the page before my nickname got populated at the top. This will fix the bug.